### PR TITLE
Improve pronoun game UX

### DIFF
--- a/pronoun-practice-tool.html
+++ b/pronoun-practice-tool.html
@@ -24,6 +24,8 @@
         .tool-intro { text-align: center; margin-bottom: 2.5rem; }
         #category-selection { display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem; margin-bottom: 3rem; }
         #category-selection .btn { min-width: 180px; }
+        #start-screen { text-align: center; margin-bottom: 2rem; }
+        #start-screen .btn { margin-top: 1rem; }
         #practice-area { background-color: var(--color-bg); padding: 1.5rem 2.5rem 2rem; border-radius: 8px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.07); border-left: 5px solid var(--color-primary); }
         .game-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; height: 30px; }
         #hint-container { font-size: 1rem; color: var(--color-text-light); }
@@ -103,9 +105,12 @@
                 <h1><span class="emoji">🏆</span> The Great Pronoun Game</h1>
                 <p class="intro-text">Master Dutch pronouns in a fun way! Choose a category, track your high scores, and unlock achievements. Veel succes!</p>
             </div>
-
+            <div id='start-screen'>
+                <p>Welcome! Press Start to choose a category. You'll answer 10 questions per round. Type the missing word and hit Enter. Use hints if you're stuck — they reset your streak. Score 8/10 in each category to unlock Challenge Mode. Your progress saves automatically and you can toggle sounds with the speaker icon.</p>
+                <button id='start-btn' class='btn btn-primary'>Start</button>
+            </div>
             <!-- Category Selection -->
-            <div id="category-selection">
+            <div id="category-selection" class="hidden">
                 <button class="btn btn-primary" data-category="subject">Subject Pronouns</button>
                 <button class="btn btn-primary" data-category="object">Object Pronouns</button>
                 <button class="btn btn-secondary" data-category="demonstrative">Demonstratives</button>
@@ -183,8 +188,8 @@
     </main>
 
     <div id="toast" class="toast hidden"></div>
-    <audio id="correct-sound" src="https://www.fesliyanstudios.com/play-mp3/387"></audio>
-    <audio id="incorrect-sound" src="https://www.fesliyanstudios.com/play-mp3/438"></audio>
+    <audio id="correct-sound" src="https://cdn.freesound.org/previews/18/18665_6281-hq.mp3"></audio>
+    <audio id="incorrect-sound" src="https://cdn.freesound.org/previews/240/240195_2953000-hq.mp3"></audio>
     <footer class="footer"></footer>
 
     <script src="script.js"></script> <!-- Your existing script for nav/footer -->
@@ -203,7 +208,7 @@
                 { category: 'subject', sentence: 'De kinderen spelen buiten. ___ maken veel lawaai.', answer: ['zij', 'ze'], explanation: '"De kinderen" is plural, so "zij/ze".' },
 
                 { category: 'object', sentence: 'Ik zie de postbode. Ik geef ___ een brief.', answer: ['hem'], explanation: 'Use "hem" for a male person.' },
-                { category: 'object', sentence: 'Mikaella is mijn vriendin. Ik bel ___ elke dag.', answer: ['haar'], explanation: 'Female person -> "haar".' },
+                { category: 'object', sentence: 'Mijn vriendin is jarig. Ik bel ___ meteen.', answer: ['haar'], explanation: 'Female person -> "haar".' },
                 { category: 'object', sentence: 'Dit is mijn nieuwe telefoon. Vind je ___ mooi?', answer: ['hem'], explanation: '"Telefoon" is a de-word, so object pronoun is "hem".' },
                 { category: 'object', sentence: 'Ik begrijp het niet. Kun je ___ helpen?', answer: ['mij', 'me'], explanation: 'First person object is "mij/me".' },
                 { category: 'object', sentence: 'Onze leraar is ziek. We sturen ___ een kaart.', answer: ['hem'], explanation: 'Male teacher -> "hem".' },
@@ -248,6 +253,8 @@
             const toast = document.getElementById('toast');
             const correctSound = document.getElementById('correct-sound');
             const incorrectSound = document.getElementById('incorrect-sound');
+            const startScreen = document.getElementById("start-screen");
+            const startBtn = document.getElementById("start-btn");
             const soundToggle = document.getElementById('sound-toggle');
 
             let soundEnabled = true;
@@ -514,6 +521,10 @@
             }
 
             function initialize() {
+                startScreen.classList.remove("hidden");
+                categorySelection.classList.add("hidden");
+                practiceArea.classList.add("hidden");
+                completionScreen.classList.add("hidden");
                 loadProgress();
                 updateUIFromState();
                 updateSoundIcon();
@@ -538,9 +549,14 @@
                 startGame('mistakes', wrongQuestions);
                 wrongQuestions = [];
             });
-            playAgainBtn.addEventListener('click', () => {
-                completionScreen.classList.add('hidden');
-                categorySelection.classList.remove('hidden');
+            playAgainBtn.addEventListener("click", () => {
+                completionScreen.classList.add("hidden");
+                categorySelection.classList.remove("hidden");
+            });
+
+            startBtn.addEventListener("click", () => {
+                startScreen.classList.add("hidden");
+                categorySelection.classList.remove("hidden");
             });
             answerInput.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter' && !checkBtn.classList.contains('hidden')) {


### PR DESCRIPTION
## Summary
- add a start screen with instructions
- remove personal reference from sentence list
- play upbeat cheer and fail sounds

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846d0902428832990003d051aac79b8