### PR TITLE
Improve pronoun game flow

### DIFF
--- a/pronoun-practice-tool.html
+++ b/pronoun-practice-tool.html
@@ -22,20 +22,22 @@
     <!-- Custom styles for the interactive game -->
     <style>
         .tool-intro { text-align: center; margin-bottom: 2.5rem; }
-        #category-selection { display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem; margin-bottom: 3rem; }
+        .game-field {
+            background-color: var(--color-bg);
+            padding: 2rem 2.5rem;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.07);
+            border-left: 5px solid var(--color-primary);
+            margin-bottom: 3rem;
+        }
+        #category-selection { display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem; margin-bottom: 2rem; }
         #category-selection .btn { min-width: 180px; }
         #start-screen {
             text-align: center;
             margin-bottom: 2rem;
-            background-color: #eff6ff;
-            border: 1px solid #dbeafe;
-            padding: 2rem 1.5rem;
-            border-radius: 8px;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.07);
         }
         #start-screen p { font-size: 1.1rem; margin-bottom: 1.5rem; }
         #start-screen .btn { margin-top: 0.5rem; }
-        #practice-area { background-color: var(--color-bg); padding: 1.5rem 2.5rem 2rem; border-radius: 8px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.07); border-left: 5px solid var(--color-primary); }
         .game-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; height: 30px; }
         #hint-container { font-size: 1rem; color: var(--color-text-light); }
         #hint-btn { background: none; border: 1px solid var(--color-text-light); color: var(--color-text-light); padding: 0.2rem 0.6rem; border-radius: 4px; cursor: pointer; transition: all 0.2s ease; }
@@ -54,7 +56,7 @@
         #feedback-message { min-height: 1.5em; margin-top: 1rem; text-align: center; font-weight: 600; }
         #feedback-message.correct { color: var(--color-secondary); }
         #feedback-message.incorrect { color: var(--color-accent); }
-        #completion-screen { text-align: center; padding: 3rem 1.5rem; background-color: #eff6ff; border: 1px solid #dbeafe; border-radius: 8px; }
+        #completion-screen { text-align: center; padding: 3rem 1.5rem; }
         #completion-stats { display: flex; justify-content: center; gap: 2rem; margin: 1rem 0 2rem 0; text-align: center; flex-wrap: wrap; }
         .stat-item h4 { color: var(--color-text-light); margin-bottom: 0.25rem; font-size: 1rem; font-weight: 500; }
         .stat-item p { color: var(--color-primary); font-size: 1.8rem; font-weight: 700; margin: 0; }
@@ -83,7 +85,11 @@
         .toast .emoji { margin-right: 0.75rem; font-size: 1.2rem; }
 
         @media (max-width: 768px) {
-            #practice-area { padding: 1.5rem; }
+            .game-field { padding: 1.5rem; }
+            #category-selection { flex-direction: column; }
+            #category-selection .btn { width: 100%; min-width: 0; }
+            #start-screen p { font-size: 1rem; }
+            #completion-screen { padding: 2rem 1rem; }
             #sentence-container { font-size: 1.2rem; }
             #answer-input { font-size: 1.1rem; }
         }
@@ -115,6 +121,7 @@
                 <h1><span class="emoji">🏆</span> The Great Pronoun Game</h1>
                 <p class="intro-text">Master Dutch pronouns in a fun way! Choose a category, track your high scores, and unlock achievements. Veel succes!</p>
             </div>
+            <div id="game-field" class="game-field">
             <div id='start-screen'>
                 <h2><span class="emoji">🎮</span> Ready to Play?</h2>
                 <p>Welcome! Press Start to choose a category. You'll answer 10 questions per round. Type the missing word and hit Enter. Use hints if you're stuck — they reset your streak. Score 8/10 in each category to unlock Challenge Mode. Your progress saves automatically and you can toggle sounds with the speaker icon.</p>
@@ -171,7 +178,8 @@
                 </div>
                 <button id="play-again-btn" class="btn btn-primary">Play Another Round</button>
                 <button id="practice-mistakes-btn" class="btn btn-secondary hidden">Practice My Mistakes</button>
-            </div>
+            </div> <!-- end completion-screen -->
+            </div> <!-- end game-field -->
 
             <!-- Achievements -->
             <div id="achievements-container">


### PR DESCRIPTION
## Summary
- keep pronoun game intro, category menu and round results in one card
- make the game field and intro mobile friendly

## Testing
- `tidy -errors pronoun-practice-tool.html`

------
https://chatgpt.com/codex/tasks/task_e_68473540cdb08329a8de45c4a9ae1a70