### PR TITLE
Enable Enter key for pronoun game progression

### DIFF
--- a/pronoun-practice-tool.html
+++ b/pronoun-practice-tool.html
@@ -599,10 +599,16 @@
                 startScreen.classList.add("hidden");
                 categorySelection.classList.remove("hidden");
             });
+            // Allow answering the question with Enter while the input is active
             answerInput.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter' && !checkBtn.classList.contains('hidden')) {
                     checkAnswer();
-                } else if (e.key === 'Enter' && !nextBtn.classList.contains('hidden')) {
+                }
+            });
+
+            // Also listen globally so Enter can advance to the next question
+            document.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' && !nextBtn.classList.contains('hidden')) {
                     nextQuestion();
                 }
             });


### PR DESCRIPTION
## Summary
- improve keyboard control in pronoun game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684740bfd4248329b743637f5eb9a14c