### PR TITLE
Fix challenge mode migration

### DIFF
--- a/pronoun-practice-tool.html
+++ b/pronoun-practice-tool.html
@@ -603,8 +603,15 @@
                 const savedProgress = JSON.parse(localStorage.getItem('safeHavenPronounGame'));
                 if (savedProgress) {
                     highScores = savedProgress.highScores || {};
+                    let migrated = false;
+                    if (highScores.demonstratives !== undefined && highScores.demonstrative === undefined) {
+                        highScores.demonstrative = highScores.demonstratives;
+                        delete highScores.demonstratives;
+                        migrated = true;
+                    }
                     achievements = savedProgress.achievements || {};
                     soundEnabled = savedProgress.sound !== false;
+                    if (migrated) saveProgress();
                 }
             }
 


### PR DESCRIPTION
## Summary
- migrate any stored `demonstratives` key to `demonstrative` in the pronoun game
- persist the migration to localStorage to ensure Challenge Mode unlocks

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6847443af89c83299d971a8422c6009d