### PR TITLE
Add resources page and streamline navigation

### DIFF
--- a/header.html
+++ b/header.html
@@ -5,11 +5,9 @@
         </a>
         <ul class="nav-menu" id="nav-menu">
             <li><a href="index.html#home" class="nav-link">Home</a></li>
-            <li><a href="index.html#about" class="nav-link">About Me</a></li>
-            <li><a href="index.html#approach" class="nav-link">Approach</a></li>
+            <li><a href="index.html#about" class="nav-link">About</a></li>
+            <li><a href="resources.html" class="nav-link">Resources</a></li>
             <li><a href="blog.html" class="nav-link">Blog</a></li>
-            <li><a href="feelings-flags.html" class="nav-link">Feelings</a></li>
-            <li><a href="integration-checklist.html" class="nav-link">Checklist</a></li>
             <li><a href="index.html#contact" class="nav-link">Contact</a></li>
         </ul>
         <button class="nav-toggle" id="nav-toggle" aria-label="Menu">

--- a/pronoun-practice-tool.html
+++ b/pronoun-practice-tool.html
@@ -124,6 +124,7 @@
                 </div>
             </div>
             
+            <p style="text-align: center; margin-top: 2rem;"><a href="resources.html" class="back-link"><i class="fas fa-arrow-left"></i> Back to Resources</a></p>
         </div>
     </main>
 

--- a/resources.html
+++ b/resources.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Free Tools & Resources | Safe Haven Dutch Coaching</title>
+    <meta name="description" content="Interactive tools and guides to support Dutch language learning and integration for expat families in Groningen.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&family=Poppins:wght@500;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+    <link rel="stylesheet" href="css/style.min.css">
+</head>
+<body id="page-resources">
+    <header class="header"></header>
+
+    <main class="page-container">
+        <div class="container">
+
+            <h1 class="text-center" style="color: var(--color-primary); margin-bottom: 1rem;">Free Tools & Resources</h1>
+            <p class="text-center text-light" style="max-width: 700px; margin: 0 auto 3.5rem auto;">Explore interactive tools to support your family's Dutch learning and integration journey.</p>
+
+            <div class="blog-listing">
+                <div class="blog-preview-card slide-up">
+                    <div class="preview-image">
+                        <img src="Safety.jpg" alt="Feelings check-in tool preview">
+                    </div>
+                    <div class="preview-text">
+                        <h3><a href="feelings-flags.html">Feelings Check-in Tool</a></h3>
+                        <p class="excerpt">Discover Dutch emotion words and gentle coping ideas together. A playful way to talk about feelings.</p>
+                        <a href="feelings-flags.html" class="btn btn-secondary">Open Tool <i class="fas fa-arrow-right" style="margin-left: 5px;"></i></a>
+                    </div>
+                </div>
+
+                <div class="blog-preview-card slide-up delay-1">
+                    <div class="preview-image">
+                        <img src="integration-navigation-support.jpg" alt="Checklist preview image">
+                    </div>
+                    <div class="preview-text">
+                        <h3><a href="integration-checklist.html">Groningen Integration Checklist</a></h3>
+                        <p class="excerpt">Track essential settling-in tasks with an interactive progress bar and helpful links.</p>
+                        <a href="integration-checklist.html" class="btn btn-secondary">Use Checklist <i class="fas fa-arrow-right" style="margin-left: 5px;"></i></a>
+                    </div>
+                </div>
+
+                <div class="blog-preview-card slide-up delay-2">
+                    <div class="preview-image">
+                        <img src="Playful.jpg" alt="Pronoun game preview image">
+                    </div>
+                    <div class="preview-text">
+                        <h3><a href="pronoun-practice-tool.html">Dutch Pronoun Game</a></h3>
+                        <p class="excerpt">A gamified quiz to master Dutch subject and object pronouns. Earn badges and track high scores.</p>
+                        <a href="pronoun-practice-tool.html" class="btn btn-secondary">Play Now <i class="fas fa-arrow-right" style="margin-left: 5px;"></i></a>
+                    </div>
+                </div>
+
+                <div class="blog-preview-card slide-up delay-3">
+                    <div class="preview-image">
+                        <img src="integration-tool-preview.jpg" alt="Integration flashcards preview image">
+                    </div>
+                    <div class="preview-text">
+                        <h3><a href="integration-flashcards.html">Integration Flashcards</a></h3>
+                        <p class="excerpt">Flip through quick answers to common questions about getting settled in Groningen.</p>
+                        <a href="integration-flashcards.html" class="btn btn-secondary">Explore <i class="fas fa-arrow-right" style="margin-left: 5px;"></i></a>
+                    </div>
+                </div>
+            </div>
+
+            <a href="index.html" class="back-link" style="display: block; margin-top: 3rem; text-align: center;"><i class="fas fa-arrow-left"></i> Back to Home</a>
+
+        </div>
+    </main>
+
+    <footer class="footer">
+        <!-- Footer content will be loaded here by JavaScript -->
+    </footer>
+
+    <script src="js/script.js"></script>
+</body>
+</html>

--- a/tck-emotional-support.html
+++ b/tck-emotional-support.html
@@ -85,6 +85,7 @@
             <h2 style="color: var(--color-secondary); margin-top: 2rem;"><span class="emoji">❤️</span> You’re Doing Better Than You Think</h2>
             <p>If you’re reading this, you’re already a thoughtful, caring parent. You want to give your child the best chance to thrive here in the Netherlands. And I’m here to walk with you.</p>
             <p>At Safe Haven, we focus on more than just grammar and pronunciation. We offer a soft landing – a practical, heart-centered approach to help your child adjust, belong, and grow.</p>
+<p>For a gentle way to explore emotions together, try our <a href='feelings-flags.html'>Feelings Check-in tool</a>. If you're settling into Groningen, our <a href='integration-checklist.html'>Integration Checklist</a> can help you track key steps.</p>
 
              <!-- Optional Section for Resource Document -->
              <div class="tip-card slide-up" style="margin-top: 2.5rem; border-left-color: var(--color-primary);">

--- a/tips.html
+++ b/tips.html
@@ -61,6 +61,7 @@
                 <h2>5. Thoughtfully Use Digital Resources</h2>
                 <h3>Online Tools</h3>
                 <p>Many apps and online resources offer basic Dutch vocabulary in fun formats. Apps such as <a href="https://www.dinolingo.com/nl/learn-dutch-for-kids/" target="_blank" rel="noopener noreferrer">Dinolingo</a> and <a href="https://www.squla.nl/taal/" target="_blank" rel="noopener noreferrer">Squla</a> offer child-friendly approaches that make language learning accessible and engaging.</p>
+                <p>For extra practice with Dutch pronouns, try our <a href='pronoun-practice-tool.html'>Dutch Pronoun Game</a> for a quick challenge.</p>
             </div>
 
             <div class="tip-card slide-up">


### PR DESCRIPTION
## Summary
- simplify menu and add Resources link
- add new Resources page with cards for interactive tools
- link to Pronoun Game from blog tips
- link from emotional support article to Feelings Check-in and Integration Checklist
- add back link on pronoun game page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68488a7da1bc8329b4bcbe6a66791b91