### PR TITLE
Add privacy policy page

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,416 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy | Safe Haven Dutch Coaching</title>
+    <meta name="description" content="Privacy Policy for Safe Haven Dutch Coaching.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&family=Poppins:wght@500;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+    <link rel="stylesheet" href="css/style.min.css">
+    <link rel="stylesheet" href="css/extras.min.css">
+</head>
+<body id="privacy-policy-page">
+    <header class="header"></header>
+
+    <main>
+        <div class="page-container">
+            <div class="container slide-up">
+                <div class="blog-content tos-content">
+<h1 id="privacy-policy-for-safe-haven-dutch-coaching">Privacy Policy for
+Safe Haven Dutch Coaching</h1>
+<p><strong>Effective Date:</strong> 10 June 2025 <strong>Last
+Updated:</strong> 10 June 2025 <strong>Website:</strong>
+https://www.safehavendutch.nl</p>
+<h2 id="plain-language-summary">Plain-Language Summary</h2>
+<p>I care deeply about each student’s privacy. This policy explains:</p>
+<ol type="1">
+<li><strong>What I collect</strong> (your name, contact, lesson notes,
+payment data).</li>
+<li><strong>Why I use it</strong> (to teach, bill, improve lessons,
+communicate with you).</li>
+<li><strong>Who I share it with</strong> (only trusted services like
+Clockify, ChatGPT, Google Drive, Stripe, TransIP).</li>
+<li><strong>How long I keep it</strong> (from 30 days up to 5 years,
+depending on the data).</li>
+<li><strong>Your rights</strong> (access, correction, deletion).</li>
+<li><strong>Special care for children’s data</strong>.</li>
+</ol>
+<p>You can jump to any section using the menu below:</p>
+<ul>
+<li><a href="#1-definitions--scope">1. Definitions &amp; Scope</a></li>
+<li><a href="#2-what-i-collect">2. What I Collect</a></li>
+<li><a href="#3-how-i-use--retain-your-data">3. How I Use &amp; Retain
+Your Data</a></li>
+<li><a href="#4-childrens-privacy">4. Children’s Privacy</a></li>
+<li><a href="#5-legal-bases-for-processing">5. Legal Bases for
+Processing</a></li>
+<li><a href="#6-data-processors-third-party-services">6. Data Processors
+(Third-Party Services)</a></li>
+<li><a href="#7-international-data-transfers">7. International Data
+Transfers</a></li>
+<li><a href="#8-student-rights--how-to-exercise-them">8. Student Rights
+&amp; How to Exercise Them</a></li>
+<li><a href="#9-security-measures">9. Security Measures</a></li>
+<li><a href="#10-cookies">10. Cookies</a></li>
+<li><a href="#11-contact--supervisory-authority">11. Contact &amp;
+Supervisory Authority</a></li>
+</ul>
+<hr />
+<h2 id="definitions-scope">1. Definitions &amp; Scope</h2>
+<ul>
+<li><strong>Personal Data</strong> means any information relating to an
+identified or identifiable natural person (e.g., parent’s name, email;
+child’s first name, learning progress).</li>
+<li><strong>Services</strong> refers to all lesson platforms, coaching
+sessions, booking systems, communications, and this website provided by
+Safe Haven Dutch Coaching, operated by Florian Kersten (“we”, “us”,
+“our”).</li>
+</ul>
+<p>This policy applies to all students (children aged approximately
+6-14, “Students”) and their parents or legal guardians (“Parents,”
+“you”) who use my Services.</p>
+<h2 id="what-i-collect">2. What I Collect</h2>
+<p>We collect information necessary to provide and improve our
+Services:</p>
+<ul>
+<li><strong>Parent/Guardian Information:</strong>
+<ul>
+<li><strong>Account &amp; Contact:</strong> Your name, email address,
+password (securely hashed), phone number (optional, for urgent contact
+or scheduling).</li>
+<li><strong>Billing Information:</strong> Information required by Stripe
+for payment processing. We do not store your full credit card details on
+our servers.</li>
+</ul></li>
+<li><strong>Student Information (provided by Parent/Guardian with
+consent):</strong>
+<ul>
+<li><strong>Student Profile:</strong> Student’s first name, age or
+birthdate (for age-appropriate planning), a pseudonym code (e.g.,
+“Student A” for certain internal planning tools), lesson preferences,
+and current Dutch language level.</li>
+<li><strong>Lesson Notes:</strong> Topic summaries from lessons,
+progress assessments, pseudonymized feedback related to learning and
+well-being within the coaching context.</li>
+<li><strong>Learning Materials:</strong> Worksheets or digital materials
+shared or created during sessions.</li>
+</ul></li>
+<li><strong>Booking &amp; Payment Information:</strong> Payment records
+via Stripe, appointment dates and times, lesson duration.</li>
+<li><strong>Communications:</strong> Emails stored on TransIP mail
+servers, summaries of important communications (e.g., via our website’s
+messaging system if applicable), and pseudonymized chat summaries if AI
+tools are used for communication assistance (with your awareness).</li>
+</ul>
+<h2 id="how-i-use-retain-your-data">3. How I Use &amp; Retain Your
+Data</h2>
+<p>I only collect and use the data I need to teach effectively, bill
+accurately, communicate with you, secure my services, and improve
+lessons.</p>
+<p><strong>Purposes of Use:</strong></p>
+<ul>
+<li>To create and manage Parent and Student accounts.</li>
+<li>To schedule, plan, and deliver personalized coaching sessions.</li>
+<li>To process payments for Services via Stripe.</li>
+<li>To track Student progress and tailor lesson content.</li>
+<li>To communicate with Parents about their child’s progress,
+scheduling, and other service-related matters.</li>
+<li>To share learning materials.</li>
+<li>For AI-assisted lesson planning and content brainstorming using
+<strong>pseudonymized data</strong> (see Section 6).</li>
+<li>To comply with legal obligations (e.g., Dutch tax law).</li>
+<li>To maintain the security of our website and services (e.g., server
+logs).</li>
+</ul>
+<p><strong>Data Retention Schedule:</strong> Below is how long I keep
+each type of data:</p>
+<ul>
+<li><strong>Active Student Profiles (including lesson notes):</strong>
+Duration of lessons + 2 years (to allow for follow-up questions,
+facilitate repeat sessions, and provide continuity in learning).</li>
+<li><strong>Stripe Payment Records:</strong> 5 years (to comply with
+Dutch tax and accounting regulations).</li>
+<li><strong>Pseudonymized AI Transcripts/Inputs (e.g., for ChatGPT,
+Google AI Studio used in lesson planning):</strong> 30 days. Key
+insights are transferred to my secure, local notes, and the AI chat logs
+containing even pseudonymized data are then deleted.</li>
+<li><strong>Server Access &amp; Error Logs:</strong> 90 days (for
+security monitoring and incident investigation), then auto-deleted.</li>
+<li><strong>Full Server Backups (TransIP) &amp; iCloud Snapshots (for
+Craft/GoodNotes):</strong> Rolling 30-day rotation; older
+backups/snapshots are automatically purged.</li>
+<li><strong>Email Correspondence (TransIP):</strong> Retained for the
+duration of the active student profile + 2 years, or as long as
+necessary for ongoing communication or legal requirements.</li>
+</ul>
+<p>I automate deletion schedules where technically feasible (e.g., for
+server backups and logs) and conduct a quarterly audit of my retention
+practices.</p>
+<h2 id="childrens-privacy">4. Children’s Privacy</h2>
+<p>Protecting the privacy of children is fundamental to my Services.</p>
+<ul>
+<li><strong>Parental Consent:</strong> I collect and process Personal
+Data about Students only with the explicit, verifiable consent of a
+Parent or legal guardian, typically obtained during the booking or
+registration process.</li>
+<li><strong>Data Minimization for Children:</strong> I only collect
+information about Students that is directly relevant and necessary for
+providing effective coaching Services (e.g., first name, age for
+appropriate lesson planning, learning progress). I actively avoid
+collecting unnecessary sensitive information.</li>
+<li><strong>Use of Children’s Data:</strong> A Student’s Personal Data
+is used solely for educational purposes: to plan and deliver lessons,
+track learning progress, provide feedback to Parents, and ensure a safe
+and supportive learning environment.</li>
+<li><strong>Parental Rights for Child’s Data:</strong> As a Parent, you
+have the right to access, review, correct, or request the deletion of
+your child’s Personal Data. You can do this by contacting me.</li>
+<li><strong>No Direct Marketing to Children:</strong> I do not use
+Student’s Personal Data for direct marketing purposes.</li>
+<li><strong>Security:</strong> I apply the same robust security measures
+(detailed in Section 9) to protect Students’ Personal Data as I do for
+all Personal Data I process.</li>
+<li><strong>AI Tools &amp; Children:</strong> When AI tools are used for
+lesson planning, all Student data is strictly pseudonymized, and
+sensitive details are excluded (as detailed in Section 6).</li>
+</ul>
+<h2 id="legal-bases-for-processing">5. Legal Bases for Processing</h2>
+<p>I process your Personal Data based on the following GDPR legal
+grounds:</p>
+<ul>
+<li><strong>Consent:</strong> You (as a Parent) give explicit consent at
+the time of booking or registration for the processing of your and your
+child’s Personal Data as described in this policy, including consent for
+the use of specified third-party data processors. You can withdraw your
+consent at any time for future processing, without affecting the
+lawfulness of processing based on consent before its withdrawal.</li>
+<li><strong>Performance of a Contract:</strong> Processing is necessary
+to deliver the paid coaching Services you have requested, including
+managing bookings, providing lessons, and processing payments.</li>
+<li><strong>Legitimate Interests:</strong> I process some data for my
+legitimate interests, such as:
+<ul>
+<li>Improving lesson quality and service effectiveness (e.g., via
+analysis of pseudonymized learning patterns from AI tools or internal
+review of teaching methods).</li>
+<li>Administrative efficiency (e.g., using Clockify for time tracking of
+billable hours).</li>
+<li>Maintaining the security of my website and services. I have assessed
+that these legitimate interests do not override your or your child’s
+fundamental rights and freedoms.</li>
+</ul></li>
+<li><strong>Legal Obligation:</strong> Processing is necessary to comply
+with legal requirements, such as retaining financial records for Dutch
+tax law.</li>
+</ul>
+<h2 id="data-processors-third-party-services">6. Data Processors
+(Third-Party Services)</h2>
+<p>I use the following trusted third-party services to process your
+data. For each, I share only the minimum information needed for their
+specific purpose. I will obtain your explicit consent for their use.
+<em>(Please ensure these links are current and correct before
+publishing)</em></p>
+<ol type="1">
+<li><strong>TransIP (Website Hosting, Database, &amp; Email)</strong>
+<ul>
+<li><strong>Data:</strong> Website content, CMS database (including
+Parent/Student profiles, lesson bookings, etc.), email
+correspondence.</li>
+<li><strong>Purpose:</strong> Hosting the website, database, and
+managing email.</li>
+<li><strong>GDPR/Privacy Policy:</strong>
+https://www.transip.nl/gdpr/</li>
+</ul></li>
+<li><strong>Stripe (Payment Processing)</strong>
+<ul>
+<li><strong>Data:</strong> Parent name, email, billing information,
+purchase details.</li>
+<li><strong>Purpose:</strong> Securely processing payments.</li>
+<li><strong>GDPR/Privacy Policy:</strong> https://stripe.com/gb/privacy
+<em>(check for specific EU policy if available)</em></li>
+</ul></li>
+<li><strong>Clockify (Time Tracking)</strong>
+<ul>
+<li><strong>Data:</strong> Student first name (or pseudonym), lesson
+duration.</li>
+<li><strong>Purpose:</strong> Accurately tracking billable hours.</li>
+<li><strong>GDPR/Privacy Policy:</strong> https://clockify.me/gdpr</li>
+</ul></li>
+<li><strong>OpenAI (ChatGPT - for AI Assistance)</strong>
+<ul>
+<li><strong>Data:</strong> Pseudonymized Student learning needs/contexts
+(e.g., “Student A, age 8, is working on past tense verbs”), general
+lesson planning queries. <strong>No directly identifiable personal data
+(full names, addresses, specific sensitive details) are
+shared.</strong></li>
+<li><strong>Purpose:</strong> Assisting in drafting lesson plans and
+educational content.</li>
+<li><strong>GDPR/Privacy Policy:</strong> <a
+href="https://openai.com/policies/privacy-policy">https://openai.com/policies/privacy-policy</a>
+(and API data usage policies: <a
+href="https://openai.com/policies/api-data-usage-policies">https://openai.com/policies/api-data-usage-policies</a>)</li>
+<li><strong>My Practice:</strong> Student data is always pseudonymized.
+Sensitive details are excluded. I delete AI chat logs containing
+pseudonymized student project data from my account with the AI provider
+within 30 days.</li>
+</ul></li>
+<li><strong>Google (Google AI Studio, Google Drive/Docs)</strong>
+<ul>
+<li><strong>Google AI Studio Data:</strong> Pseudonymized Student
+information (similar to ChatGPT) for brainstorming content.</li>
+<li><strong>Google Drive/Docs Data:</strong> Shared educational
+materials, worksheets which may contain Student first names (for
+identification within the shared document context) and lesson-related
+content.</li>
+<li><strong>Purpose:</strong> AI-assisted brainstorming; creating and
+sharing educational materials.</li>
+<li><strong>GDPR/Privacy Policy:</strong>
+https://policies.google.com/privacy</li>
+</ul></li>
+<li><strong>Apple (Craft for MacOS / iCloud - Document Drafting &amp;
+Storage/Backups)</strong>
+<ul>
+<li><strong>Data:</strong> Draft documents about lesson structure,
+notes; these may contain pseudonymized Student information. iCloud also
+stores backups of data from apps like GoodNotes and Craft.</li>
+<li><strong>Purpose:</strong> Creating, organizing lesson planning
+materials, and app data backup.</li>
+<li><strong>GDPR/Privacy Policy:</strong>
+https://www.apple.com/legal/privacy/</li>
+</ul></li>
+<li><strong>GoodNotes (Shared Lesson Notes)</strong>
+<ul>
+<li><strong>Data:</strong> Shared digital lesson notes, which may
+include Student first names or pseudonyms and lesson content.</li>
+<li><strong>Purpose:</strong> Creating and sharing interactive digital
+lesson notes.</li>
+<li><strong>GDPR/Privacy Policy:</strong>
+https://www.goodnotes.com/privacy-policy</li>
+</ul></li>
+</ol>
+<h2 id="international-data-transfers">7. International Data
+Transfers</h2>
+<p>Some of the Data Processors I use (e.g., OpenAI, Google, Apple,
+Stripe, and potentially Clockify/GoodNotes depending on their
+infrastructure) may store or process data outside the European Economic
+Area (EEA), primarily in the United States.</p>
+<p>When Personal Data is transferred outside the EEA, I ensure that
+appropriate safeguards are in place to protect your data in accordance
+with GDPR requirements. These safeguards typically include:</p>
+<ul>
+<li>The processor being located in a country deemed by the European
+Commission to provide an adequate level of data protection.</li>
+<li>The use of Standard Contractual Clauses (SCCs) approved by the
+European Commission.</li>
+<li>For transfers to the US, reliance on frameworks like the EU-U.S.
+Data Privacy Framework (if the provider is certified) or SCCs.</li>
+</ul>
+<p>You can find more information about these safeguards in the
+respective privacy policies of the Data Processors linked in Section 6.
+For AI tools, my primary safeguard is the pseudonymization of any
+student-related data before it is processed by non-EEA services.</p>
+<h2 id="student-rights-how-to-exercise-them">8. Student Rights &amp; How
+to Exercise Them</h2>
+<p>Under GDPR, Parents (on behalf of themselves and their Student) have
+the right to:</p>
+<ul>
+<li><strong>Access:</strong> Request a copy of the Personal Data I hold
+about you and/or your Student.</li>
+<li><strong>Correction (Rectification):</strong> Request updates or
+corrections to inaccurate or incomplete Personal Data.</li>
+<li><strong>Deletion (Erasure / Right to be Forgotten):</strong> Ask me
+to erase Personal Data, unless I am legally required or have an
+overriding legitimate interest to keep it (e.g., payment records for tax
+law).</li>
+<li><strong>Portability:</strong> Receive Personal Data you have
+provided to me in a structured, commonly used, and machine-readable
+format, and have the right to transmit that data to another controller
+where technically feasible.</li>
+<li><strong>Object:</strong> Object to the processing of Personal Data
+based on my legitimate interests.</li>
+<li><strong>Withdraw Consent:</strong> Withdraw your consent at any time
+for future processing where consent is the legal basis. This will not
+affect the lawfulness of processing based on consent before its
+withdrawal.</li>
+<li><strong>Restrict Processing:</strong> Request the restriction of
+processing of Personal Data under certain circumstances.</li>
+</ul>
+<p><strong>To exercise any right:</strong> Email me at
+<code>florian@safehavendutch.nl</code> with the Subject: <strong>GDPR
+Request</strong>. I will verify your identity (to protect your data) and
+respond within 30 days (this period may be extended by two further
+months where necessary, taking into account the complexity and number of
+requests, in which case I will inform you). There is generally no fee
+for exercising these rights, unless requests are manifestly unfounded or
+excessive.</p>
+<h2 id="security-measures">9. Security Measures</h2>
+<p>I take the security of your Personal Data seriously and implement
+appropriate technical and organizational measures:</p>
+<ul>
+<li><strong>In Transit:</strong> SSL/TLS certificate via TransIP for all
+website traffic, ensuring data is encrypted between your browser and my
+server.</li>
+<li><strong>At Rest:</strong>
+<ul>
+<li>MySQL database with table-level encryption enabled on TransIP
+servers.</li>
+<li>Data stored with third-party cloud services like Apple iCloud and
+Google Drive is encrypted by those providers by default.</li>
+</ul></li>
+<li><strong>Access Controls:</strong> Strong passwords and restricted
+access to backend systems and databases.</li>
+<li><strong>Firewall &amp; WAF:</strong> TransIP server-level firewall
+active. Exploring Cloudflare free-tier Web Application Firewall (WAF)
+for enhanced protection.</li>
+<li><strong>Monitoring:</strong> Weekly review of SSH access logs and
+server error logs. Quarterly vulnerability scans planned.</li>
+<li><strong>Software Security:</strong> Use of PDO prepared statements
+to prevent SQL injection, CSRF tokens on forms, and secure session
+management.</li>
+</ul>
+<h2 id="cookies">10. Cookies</h2>
+<p>My custom CMS uses only:</p>
+<ul>
+<li><strong>Strictly Necessary Session Cookies (e.g.,
+<code>PHPSESSID</code>):</strong> Essential for website functionality,
+such as logging you into your Parent dashboard. These are HTTPS-only and
+are deleted when you close your browser.</li>
+<li><strong>CSRF Cookies:</strong> For security to protect forms against
+Cross-Site Request Forgery.</li>
+</ul>
+<p>I do <strong>not</strong> use tracking cookies or local-storage data
+for tracking individuals across websites or for advertising
+purposes.</p>
+<h2 id="contact-supervisory-authority">11. Contact &amp; Supervisory
+Authority</h2>
+<p>If you have any questions or concerns about this Privacy Policy or my
+data practices, please contact me: Florian Kersten Safe Haven Dutch
+Coaching Email: <code>florian@safehavendutch.nl</code></p>
+<p>You also have the right to lodge a complaint with the Dutch Data
+Protection Authority (Autoriteit Persoonsgegevens) if you believe your
+data protection rights have been infringed:</p>
+<p><strong>Autoriteit Persoonsgegevens</strong> P.O. Box 93374 2509 AJ
+Den Haag Phone: +31 (0)70 888 85 00 Website:
+https://www.autoriteitpersoonsgegevens.nl</p>
+<hr />
+<p>Thank you for trusting Safe Haven Dutch Coaching with your learning
+journey. I am committed to protecting your privacy with neighborly care
+and respect.</p>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <!-- Footer content will be loaded here by JavaScript -->
+    </footer>
+
+    <script src="js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- convert privacy-policy.md to a styled HTML page
- keep same look & feel as terms page with dynamic header/footer

## Testing
- `pandoc --version`

------
https://chatgpt.com/codex/tasks/task_e_684899aeaedc8329848ddd0438e993da