### PR TITLE
Improve sentence randomization

### DIFF
--- a/pronoun-practice-tool.html
+++ b/pronoun-practice-tool.html
@@ -686,11 +686,19 @@
             }
 
             function shuffleArray(array) {
-                for (let i = array.length - 1; i > 0; i--) {
-                    const j = Math.floor(Math.random() * (i + 1));
-                    [array[i], array[j]] = [array[j], array[i]];
+                const arr = array.slice();
+                for (let i = arr.length - 1; i > 0; i--) {
+                    let j;
+                    if (window.crypto && window.crypto.getRandomValues) {
+                        const rand = new Uint32Array(1);
+                        window.crypto.getRandomValues(rand);
+                        j = rand[0] % (i + 1);
+                    } else {
+                        j = Math.floor(Math.random() * (i + 1));
+                    }
+                    [arr[i], arr[j]] = [arr[j], arr[i]];
                 }
-                return array;
+                return arr;
             }
 
             // Capitalize first letter of a category for toast messages


### PR DESCRIPTION
## Summary
- use crypto-based shuffle to better randomize pronoun sentences

## Testing
- `node -e "function shuffleArray(array){const arr=array.slice();for(let i=arr.length-1;i>0;i--){let j;if(globalThis.crypto&&crypto.getRandomValues){const r=new Uint32Array(1);crypto.getRandomValues(r);j=r[0]%(i+1);}else{j=Math.floor(Math.random()*(i+1));}[arr[i],arr[j]]=[arr[j],arr[i]];}return arr;} const arr=Array.from({length:40},(_,i)=>i+1);console.log(shuffleArray(arr).slice(0,10));"`

------
https://chatgpt.com/codex/tasks/task_e_6849ed0fd4408329aa8f709a06a28dc0