### PR TITLE
Fix tooltips on pronoun game badges

### DIFF
--- a/pronoun-practice-tool.html
+++ b/pronoun-practice-tool.html
@@ -772,6 +772,9 @@
 
             // Mobile-friendly tooltips for achievements
             document.querySelectorAll('.badge[data-tooltip]').forEach(badge => {
+                // Ensure a native browser tooltip appears on hover
+                const tip = badge.getAttribute('data-tooltip');
+                if (tip) badge.setAttribute('title', tip);
                 badge.addEventListener('click', () => {
                     badge.classList.add('show-tooltip');
                     setTimeout(() => badge.classList.remove('show-tooltip'), 2000);


### PR DESCRIPTION
## Summary
- ensure pronoun game achievement badges show native browser tooltip by setting the `title` attribute for each badge

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849fa9a657883298fdeafb89734ad59