### PR TITLE
Apply card style to privacy policy summary

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -32,6 +32,7 @@
                 <div class="blog-content tos-content">
 <h1>Safe Haven Dutch Coaching – Privacy Policy</h1>
 <p class="text-light" style="font-size: 0.9rem; margin-top: -0.8rem; margin-bottom: 2.5rem;">Effective: 1 July 2025 —— Last updated: 11 June 2025</p>
+<div class="how-to-read-box">
 <h2 id="plain-language-summary">Plain-Language Summary</h2>
 <p>I care deeply about each student’s privacy. This policy explains:</p>
 <ol type="1">
@@ -66,6 +67,7 @@ Transfers</a></li>
 <li><a href="#11-contact--supervisory-authority">11. Contact &amp;
 Supervisory Authority</a></li>
 </ul>
+</div>
 <hr />
 <h2 id="definitions-scope">1. Definitions &amp; Scope</h2>
 <ul>


### PR DESCRIPTION
## Summary
- wrap the "Plain-Language Summary" content on the privacy policy page in the existing `.how-to-read-box` card

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c03348ad483299ea8386575c1d5a2