### PR TITLE
Fix menu bar on flashcards page

### DIFF
--- a/integration-flashcards.html
+++ b/integration-flashcards.html
@@ -420,7 +420,7 @@
         }); // End DOMContentLoaded
     </script>
     <!-- Link to global script.txt if you have one for other functions -->
-    <!-- <script src="/js/script.js"></script> --> <!-- Assuming you rename script.txt -->
+    <script src="/js/script.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load global script on integration flashcards page

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684c925dc5cc8329a7674c045e59c899