### PR TITLE
Update flashcard carousel start

### DIFF
--- a/integration-flashcards.html
+++ b/integration-flashcards.html
@@ -328,7 +328,7 @@
             const flashcards = document.querySelectorAll('.flashcard-card');
             const prevBtn = document.querySelector('.carousel-btn.prev');
             const nextBtn = document.querySelector('.carousel-btn.next');
-            let currentIndex = 0;
+            let currentIndex = flashcards.length > 1 ? 1 : 0; // Start with middle card active
 
             function updateCarousel() {
                 flashcards.forEach((card, idx) => {


### PR DESCRIPTION
## Summary
- tweak integration flashcards so the middle card is active on load

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c92bdcd8883299f6c925689c6752d