### PR TITLE
Update Terms of Service holiday calendar

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -33,7 +33,7 @@
             <div class="container slide-up">
                 <div class="blog-content tos-content"> <!-- Using blog-content for base styling, tos-content for specifics -->
                     <h1>Safe Haven Dutch Coaching – Terms of Service</h1>
-                    <p class="text-light" style="font-size: 0.9rem; margin-top: -0.8rem; margin-bottom: 2.5rem;">Effective: 1 July 2025 —— Last updated: 11 June 2025</p>
+                    <p class="text-light" style="font-size: 0.9rem; margin-top: -0.8rem; margin-bottom: 2.5rem;">Effective: 1 July 2025 —— Last updated: 14 June 2025</p>
                     <div class="how-to-read-box">
                         <h2>How to read these Terms</h2>
                         <ul>
@@ -77,7 +77,7 @@
                         </li>
                         <li><strong>Coach cancellation:</strong> free reschedule or full refund.</li>
                         <li><strong>No-shows & late arrivals:</strong> session ends at the scheduled time and is charged in full.</li>
-                        <li><strong>Holiday calendar:</strong> no sessions on Dutch national holidays or during my summer break (weeks 29-30). Dates published each January.</li>
+                        <li><strong>Holiday calendar:</strong> No sessions are scheduled on Dutch national holidays. During our summer period (typically weeks 29-34), coaching availability will be significantly limited. Specific available dates and times during this period will be communicated directly to active clients and/or made visible in our booking system. Full holiday closure dates, if any, and national holiday observances are published each January.</li>
                     </ul>
 
                     <h2 id="section5">5. Fees & Payment</h2>


### PR DESCRIPTION
## Summary
- clarify holiday calendar in Terms section 4
- update Last updated date to 14 June 2025

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684db440c03c8329987e5bf2e88996a1