### PR TITLE
Tweak flashcard controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -445,6 +445,8 @@ main > section.section-card > .container {
 .flashcard-carousel {
     position: relative;
 }
+.flashcard-carousel .carousel-btn.prev { left: 10px; }
+.flashcard-carousel .carousel-btn.next { right: 10px; }
 .flashcard-grid {
     display: flex;
     gap: 3rem;
@@ -476,9 +478,9 @@ main > section.section-card > .container {
     transform: rotateY(180deg) scale(1.05);
 }
 .flashcard-face { position: absolute; width: 100%; height: 100%; backface-visibility: hidden; border-radius: 20px; display: flex; align-items: center; justify-content: center; text-align: center; padding: 1.5rem; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08); overflow: hidden; box-sizing: border-box; transition: box-shadow 0.8s ease; }
-.flashcard-front { background-color: var(--color-white); color: var(--color-primary); font-family: var(--font-heading); font-size: 1.2em; font-weight: 500; z-index: 2; transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out; }
+.flashcard-front { background-color: var(--color-white); color: var(--color-primary); font-family: var(--font-heading); font-size: 1.2em; font-weight: 600; z-index: 2; transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out; }
 .flashcard-card:not(.flipped) .flashcard-front:hover { transform: translateY(-5px); box-shadow: 0 8px 15px rgba(0, 0, 0, 0.12); }
-.flashcard-back { background-color: var(--color-bg); color: var(--color-text); transform: rotateY(180deg); flex-direction: column; align-items: center; justify-content: flex-start; text-align: center; font-family: var(--font-body); overflow-y: auto; padding-right: 1rem; }
+.flashcard-back { background-color: var(--color-bg); color: var(--color-text); transform: rotateY(180deg); flex-direction: column; align-items: center; justify-content: center; text-align: center; font-family: var(--font-body); overflow-y: auto; padding-right: 1rem; }
 .flashcard-back h4 { color: var(--color-primary); font-size: 1.1em; margin-top: 0; margin-bottom: 0.5rem; font-weight: 600; flex-shrink: 0; }
 .flashcard-back p { font-size: 1.05em; line-height: 1.5; margin-bottom: 0; flex-grow: 1; word-break: break-word; }
 .flashcard-back a { color: var(--color-secondary); text-decoration: underline; font-weight: 600; display: inline; word-break: break-word; }


### PR DESCRIPTION
## Summary
- reposition carousel buttons on integration flashcards so they're not flush with the page edges
- increase weight of flashcard front text and center content on back

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e8a72c22c83299057b6b2ca8b0f03