### PR TITLE
Fix testimonial shadow clipping

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -287,7 +287,10 @@ main > section.section-card > .container {
 
 /* --- Testimonial Carousel Styles --- */
 #testimonials { background-color: transparent; }
-.testimonial-carousel-container { overflow: hidden; }
+.testimonial-carousel-container {
+    overflow: hidden;
+    padding-bottom: 2rem;
+}
 .testimonial-track {
     display: flex;
     transition: transform 0.6s var(--easing-bounce);


### PR DESCRIPTION
## Summary
- add bottom padding to testimonials carousel container to prevent shadow clipping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68532da8fd2c8329a66b2523cc4a4a69