### PR TITLE
Add Trustpilot reviews link near testimonials

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,9 @@
                     <button class="carousel-btn prev" aria-label="Previous Testimonial"><i class="fas fa-chevron-left"></i></button>
                     <button class="carousel-btn next" aria-label="Next Testimonial"><i class="fas fa-chevron-right"></i></button>
                 </div>
+                <p class="slide-up" style="margin-top: 1rem;">
+                    <a class="btn btn-secondary" href="https://www.trustpilot.com/review/safehavendutch.nl" target="_blank" rel="noopener noreferrer">View More Reviews on Trustpilot</a>
+                </p>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add button linking to Trustpilot reviews right after the testimonial carousel

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68532f129db88329add11d2aa35a2032